### PR TITLE
export the PATH to other buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -81,3 +81,7 @@ cp $SASSC_DIR/bin/sassc $INSTALL_DIR/bin/sassc
 
 mkdir -p $PROFILE_DIR
 echo "export PATH=\$PATH:\$HOME/$INSTALL_PATH/bin" > $PROFILE_DIR/sassc.sh
+
+# Exporting the PATH variable, so that buildpacks following after this can use sassc
+BUILDPACK_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+echo "export PATH=\$PATH:$INSTALL_DIR/bin" > $BUILDPACK_DIR/export


### PR DESCRIPTION
When using this buildpack together with other buildpacks i had trouble using `sassc` since it wasn't in the `$PATH`. After some research (https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks) I found out that one has to export the variables in a special way if you'd like to use them with a buildpack following your sassc one.

Feel free to reject this PR if you think this addition isn't necessary. No bad feelings.
Cheers Philipp
